### PR TITLE
Added instanceof alias for instanceOf

### DIFF
--- a/src/checkers.js
+++ b/src/checkers.js
@@ -21,6 +21,8 @@ function getCheckers(disabled) {
     emptyObject: emptyObjectCheckGetter(),
 
     instanceOf: instanceCheckGetter,
+    instanceof: instanceCheckGetter,
+
     oneOf: oneOfCheckGetter,
     oneOfType: oneOfTypeCheckGetter,
 

--- a/src/checkers.test.js
+++ b/src/checkers.test.js
@@ -83,6 +83,9 @@ describe('checkers', () => {
     it('should check the instance of a class', () => {
       expect(checkers.instanceOf(RegExp)(/regex/)).to.be.undefined;
       expect(checkers.instanceOf(RegExp)({})).to.be.an.instanceOf(Error);
+
+      expect(checkers.instanceof(RegExp)(/regex/)).to.be.undefined;
+      expect(checkers.instanceof(RegExp)({})).to.be.an.instanceOf(Error);
     });
   });
 


### PR DESCRIPTION
This is just a simple quality of life improvement that aliases the `instanceOf` checker to `instanceof`. I was expecting the capitalization to match the actual `instanceof` operator and spent a good bit of time figuring out what I did wrong. 
