### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-check",
-  "version": "7.3.0",
+  "version": "7.5.3",
   "homepage": "https://github.com/kentcdodds/apiCheck.js",
   "authors": [
     "Kent C. Dodds <kent@doddsfamily.us> (http://kent.doddsfamily.us)"


### PR DESCRIPTION
Had an error while installing the last version from bower:
`mismatch Version declared in the json (7.3.0) is different than the resolved one (7.5.3)`

Looks like your release process needs to update the version in the bower.json file as well ;-)
